### PR TITLE
Feature: Add build tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ cmd/rpmdb/*
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+.env
+src-bundle
+
 .idea
 vendor

--- a/cmd/rpmdb/main.go
+++ b/cmd/rpmdb/main.go
@@ -1,4 +1,4 @@
-//go:build !nosqlite
+//go:build noextradeps
 
 package main
 

--- a/cmd/rpmdb/main.go
+++ b/cmd/rpmdb/main.go
@@ -1,3 +1,5 @@
+//go:build !nosqlite
+
 package main
 
 import (
@@ -5,9 +7,8 @@ import (
 	"log"
 
 	rpmdb "github.com/Zweih/go-rpmdb/pkg"
-	multierror "github.com/hashicorp/go-multierror"
-
 	_ "github.com/glebarez/go-sqlite"
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/Zweih/go-rpmdb
 
-go 1.22.0
-
-toolchain go1.24.1
+go 1.24.1
 
 require (
 	github.com/glebarez/go-sqlite v1.22.0

--- a/pkg/rpmdb_test.go
+++ b/pkg/rpmdb_test.go
@@ -1,3 +1,5 @@
+//go:build !nosqlite
+
 package rpmdb
 
 import (

--- a/pkg/rpmdb_test.go
+++ b/pkg/rpmdb_test.go
@@ -1,4 +1,4 @@
-//go:build !nosqlite
+//go:build noextradeps
 
 package rpmdb
 


### PR DESCRIPTION
Added `noextradeps` build tag to prevent unused dependencies from leaking to binaries.